### PR TITLE
Support for multi-language enum display

### DIFF
--- a/datadoc_model/BaseModel.py
+++ b/datadoc_model/BaseModel.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class DataDocBaseModel(BaseModel):
+    """Defines configuration which applies to all Models in this application"""
+
+    class Config:
+        # Runs validation when a field value is assigned, not just in the constructor
+        validate_assignment = True
+        # Write only the values of enums during serialization
+        use_enum_values = True

--- a/datadoc_model/Enums.py
+++ b/datadoc_model/Enums.py
@@ -1,4 +1,13 @@
 from enum import Enum
+from datadoc_model.LanguageStrings import LanguageStrings
+from datadoc_model.LanguageStringsEnum import LanguageStringsEnum
+
+
+class SupportedLanguages(str, Enum):
+    "Reference: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry"
+    NORSK_BOKMÅL = "nb"
+    NORSK_NYNORSK = "nn"
+    ENGLISH = "en"
 
 
 class Assessment(str, Enum):
@@ -8,26 +17,20 @@ class Assessment(str, Enum):
     OPEN = "OPEN"
 
 
-class DatasetState(str, Enum):
-    SOURCE_DATA = "SOURCE_DATA"
-    INPUT_DATA = "INPUT_DATA"
-    PROCESSED_DATA = "PROCESSED_DATA"
-    STATISTIC = "STATISTIC"
-    OUTPUT_DATA = "OUTPUT_DATA"
+class DatasetState(LanguageStringsEnum):
+    SOURCE_DATA = LanguageStrings(en="SOURCE DATA", nn="KILDEDATA", nb="KILDEDATA")
+    INPUT_DATA = LanguageStrings(en="INPUT DATA", nn="INNDATA", nb="INNDATA")
+    PROCESSED_DATA = LanguageStrings(
+        en="PROCESSED DATA", nn="KLARGJORTE DATA", nb="KLARGJORTE DATA"
+    )
+    STATISTIC = LanguageStrings(en="STATISTIC", nn="STATISTIKK", nb="STATISTIKK")
+    OUTPUT_DATA = LanguageStrings(en="OUTPUT DATA", nn="UTDATA", nb="UTDATA")
 
 
 class DatasetStatus(str, Enum):
     DRAFT = "DRAFT"
     INTERNAL = "INTERNAL"
     EXTERNAL = "EXTERNAL"
-    DEPRECATED = "DEPRECATED"
-
-
-class AdministrativeStatus(str, Enum):
-    # TODO: The definition of this property is not complete (may change)?
-    DRAFT = "DRAFT"
-    INTERNAL = "INTERNAL"
-    OPEN = "OPEN"
     DEPRECATED = "DEPRECATED"
 
 

--- a/datadoc_model/Enums.py
+++ b/datadoc_model/Enums.py
@@ -10,11 +10,18 @@ class SupportedLanguages(str, Enum):
     ENGLISH = "en"
 
 
-class Assessment(str, Enum):
+class Assessment(LanguageStringsEnum):
     # TODO: May have some kind of relation to DataSetState (SSB decision not made yet)? E.g. if "PROCSESSED_DATA" then "PROTECTED"?
-    SENSITIVE = "SENSITIVE"
-    PROTECTED = "PROTECTED"
-    OPEN = "OPEN"
+    SENSITIVE = LanguageStrings(en="SENSITIVE", nn="SENSITIV", nb="SENSITIV")
+    PROTECTED = LanguageStrings(en="PROTECTED", nn="BESKYTTET", nb="BESKYTTET")
+    OPEN = LanguageStrings(en="OPEN", nn="ÅPEN", nb="ÅPEN")
+
+
+class DatasetStatus(LanguageStringsEnum):
+    DRAFT = LanguageStrings(en="DRAFT", nn="UTKAST", nb="UTKAST")
+    INTERNAL = LanguageStrings(en="INTERNAL", nn="INTERN", nb="INTERN")
+    EXTERNAL = LanguageStrings(en="EXTERNAL", nn="EKSTERN", nb="EKSTERN")
+    DEPRECATED = LanguageStrings(en="DEPRECATED", nn="UTGÅTT", nb="UTGÅTT")
 
 
 class DatasetState(LanguageStringsEnum):
@@ -27,44 +34,44 @@ class DatasetState(LanguageStringsEnum):
     OUTPUT_DATA = LanguageStrings(en="OUTPUT DATA", nn="UTDATA", nb="UTDATA")
 
 
-class DatasetStatus(str, Enum):
-    DRAFT = "DRAFT"
-    INTERNAL = "INTERNAL"
-    EXTERNAL = "EXTERNAL"
-    DEPRECATED = "DEPRECATED"
+class UnitType(LanguageStringsEnum):
+    """See list of SSB unit types https://www.ssb.no/metadata/definisjoner-av-statistiske-enheter"""
+
+    ARBEIDSULYKKE = LanguageStrings(
+        en="WORK ACCIDENT", nn="ARBEIDSULYKKE", nb="ARBEIDSULYKKE"
+    )
+    BOLIG = LanguageStrings(en="HOUSING", nn="BOLIG", nb="BOLIG")
+    BYGNING = LanguageStrings(en="BUILDING", nn="BYGNING", nb="BYGNING")
+    EIENDOM = LanguageStrings(en="PROPERTY", nn="EIENDOM", nb="EIENDOM")
+    FAMILIE = LanguageStrings(en="FAMILY", nn="FAMILIE", nb="FAMILIE")
+    FORETAK = LanguageStrings(en="COMPANY", nn="FORETAK", nb="FORETAK")
+    FYLKE = LanguageStrings(en="REGION", nn="FYLKE", nb="FYLKE")
+    HAVNEANLOEP = LanguageStrings(en="PORT CALL", nn="HAVNEANLOEP", nb="HAVNEANLOEP")
+    HUSHOLDNING = LanguageStrings(en="HOUSEHOLD", nn="HUSHOLDNING", nb="HUSHOLDNING")
+    KJOERETOEY = LanguageStrings(en="VEHICLE", nn="KJOERETOEY", nb="KJOERETOEY")
+    KOMMUNE = LanguageStrings(en="COUNTY", nn="KOMMUNE", nb="KOMMUNE")
+    KURS = LanguageStrings(en="COURSE", nn="KURS", nb="KURS")
+    LOVBRUDD = LanguageStrings(en="CRIME", nn="LOVBRUDD", nb="LOVBRUDD")
+    PERSON = LanguageStrings(en="PERSON", nn="PERSON", nb="PERSON")
+    STAT = LanguageStrings(en="STATE", nn="STAT", nb="STAT")
+    STORFE = LanguageStrings(en="CATTLE", nn="STORFE", nb="STORFE")
+    TRAFIKKULYKKE = LanguageStrings(
+        en="TRAFFIC ACCIDENT", nn="TRAFIKKULYKKE", nb="TRAFIKKULYKKE"
+    )
+    TRANSAKSJON = LanguageStrings(en="TRANSACTION", nn="TRANSAKSJON", nb="TRANSAKSJON")
+    VARE_TJENESTE = LanguageStrings(
+        en="GOOD/SERVICE", nn="VARE/TJENESTE", nb="VARE/TJENESTE"
+    )
+    VERDIPAPIR = LanguageStrings(en="SERVICE", nn="VERDIPAPIR", nb="VERDIPAPIR")
+    VIRKSOMHET = LanguageStrings(en="BUSINESS", nn="VIRKSOMHET", nb="VIRKSOMHET")
 
 
-class UnitType(str, Enum):
-    # TODO: May change in the nearest future? See list of SSB unit types https://www.ssb.no/metadata/definisjoner-av-statistiske-enheter
-    ARBEIDSULYKKE = "ARBEIDSULYKKE"
-    BOLIG = "BOLIG"
-    BYGNING = "BYGNING"
-    EIENDOM = "EIENDOM"
-    FAMILIE = "FAMILIE"
-    FORETAK = "FORETAK"
-    FYLKE = "FYLKE"
-    HAVNEANLOEP = "HAVNEANLOEP"
-    HUSHOLDNING = "HUSHOLDNING"
-    KJOERETOEY = "KJOERETOEY"
-    KOMMUNE = "KOMMUNE"
-    KURS = "KURS"
-    LOVBRUDD = "LOVBRUDD"
-    PERSON = "PERSON"
-    STAT = "STAT"
-    STORFE = "STORFE"
-    TRAFIKKULYKKE = "TRAFIKKULYKKE"
-    TRANSAKSJON = "TRANSAKSJON"
-    VARE_TJENESTE = "VARE_TJENESTE"
-    VERDIPAPIR = "VERDIPAPIR"
-    VIRKSOMHET = "VIRKSOMHET"
-
-
-class TemporalityType(str, Enum):
+class TemporalityType(LanguageStringsEnum):
     # More information about temporality type: https://statistics-norway.atlassian.net/l/c/HV12q90R
-    FIXED = "FIXED"
-    STATUS = "STATUS"
-    ACCUMULATED = "ACCUMULATED"
-    EVENT = "EVENT"
+    FIXED = LanguageStrings(en="FIXED", nn="FAST", nb="FAST")
+    STATUS = LanguageStrings(en="STATUS", nn="TVERRSNITT", nb="TVERRSNITT")
+    ACCUMULATED = LanguageStrings(en="ACCUMULATED", nn="AKKUMULERT", nb="AKKUMULERT")
+    EVENT = LanguageStrings(en="EVENT", nn="HENDELSE", nb="HENDELSE")
 
 
 class Datatype(str, Enum):

--- a/datadoc_model/Enums.py
+++ b/datadoc_model/Enums.py
@@ -74,17 +74,19 @@ class TemporalityType(LanguageStringsEnum):
     EVENT = LanguageStrings(en="EVENT", nn="HENDELSE", nb="HENDELSE")
 
 
-class Datatype(str, Enum):
-    STRING = "STRING"
-    INTEGER = "INTEGER"
-    FLOAT = "FLOAT"
-    DATETIME = "DATETIME"
-    BOOLEAN = "BOOLEAN"
+class Datatype(LanguageStringsEnum):
+    STRING = LanguageStrings(en="STRING", nn="TEKST", nb="TEKST")
+    INTEGER = LanguageStrings(en="INTEGER", nn="HELTALL", nb="HELTALL")
+    FLOAT = LanguageStrings(en="FLOAT", nn="DESIMALTALL", nb="DESIMALTALL")
+    DATETIME = LanguageStrings(en="DATETIME", nn="DATOTID", nb="DATOTID")
+    BOOLEAN = LanguageStrings(en="BOOLEAN", nn="BOOLSK", nb="BOOLSK")
 
 
-class VariableRole(str, Enum):
-    IDENTIFIER = "IDENTIFIER"
-    MEASURE = "MEASURE"
-    START_TIME = "START_TIME"
-    STOP_TIME = "STOP_TIME"
-    ATTRIBUTE = "ATTRIBUTE"
+class VariableRole(LanguageStringsEnum):
+    IDENTIFIER = LanguageStrings(
+        en="IDENTIFIER", nn="IDENTIFIKATOR", nb="IDENTIFIKATOR"
+    )
+    MEASURE = LanguageStrings(en="MEASURE", nn="MÅLEVARIABEL", nb="MÅLEVARIABEL")
+    START_TIME = LanguageStrings(en="START_TIME", nn="STARTTID", nb="STARTTID")
+    STOP_TIME = LanguageStrings(en="STOP_TIME", nn="STOPPTID", nb="STOPPTID")
+    ATTRIBUTE = LanguageStrings(en="ATTRIBUTE", nn="ATTRIBUTT", nb="ATTRIBUTT")

--- a/datadoc_model/LanguageStrings.py
+++ b/datadoc_model/LanguageStrings.py
@@ -1,0 +1,7 @@
+from datadoc_model.BaseModel import DataDocBaseModel
+
+
+class LanguageStrings(DataDocBaseModel):
+    en: str = ""
+    nn: str = ""
+    nb: str = ""

--- a/datadoc_model/LanguageStringsEnum.py
+++ b/datadoc_model/LanguageStringsEnum.py
@@ -10,8 +10,21 @@ if TYPE_CHECKING:
 
 class LanguageStringsEnum(Enum):
     def __init__(self, language_strings: "LanguageStrings"):
+        """Store the LanguageStrings object for displaying enum values
+        in multiple languages.
+
+        We don't particularly care what the value of the enum is,
+        but when serialised it's convenient and readable to use the
+        name of the enum, so we set the value to be the name.
+        """
         self._value_ = self.name
         self.language_strings = language_strings
 
+    @classmethod
+    def _missing_(cls, value):
+        """Support constructing an enum member from a supplied name string"""
+        return cls._member_map_[value]
+
     def get_value_for_language(self, language: "SupportedLanguages") -> str:
+        """Retrieve the string for the relevant language"""
         return getattr(self.language_strings, language.value)

--- a/datadoc_model/LanguageStringsEnum.py
+++ b/datadoc_model/LanguageStringsEnum.py
@@ -1,0 +1,17 @@
+from enum import Enum
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    # Avoid circular imports
+    from datadoc_model.LanguageStrings import LanguageStrings
+    from datadoc_model.Enums import SupportedLanguages
+
+
+class LanguageStringsEnum(Enum):
+    def __init__(self, language_strings: "LanguageStrings"):
+        self._value_ = self.name
+        self.language_strings = language_strings
+
+    def get_value_for_language(self, language: "SupportedLanguages") -> str:
+        return getattr(self.language_strings, language.value)

--- a/datadoc_model/Model.py
+++ b/datadoc_model/Model.py
@@ -23,7 +23,7 @@ class DataDocDataSet(DataDocBaseModel):
     short_name: Optional[
         constr(min_length=1, max_length=63, regex=ALPHANUMERIC_HYPHEN_UNDERSCORE)
     ]
-    assessment: Optional[Enums.Assessment]
+    assessment: Optional[Enums.Assessment] = Enums.Assessment.SENSITIVE
     dataset_status: Optional[Enums.DatasetStatus] = Enums.DatasetStatus.DRAFT
     dataset_state: Optional[Enums.DatasetState]
     name: Optional[LanguageStrings]
@@ -42,36 +42,6 @@ class DataDocDataSet(DataDocBaseModel):
     created_by: Optional[str]
     last_updated_date: Optional[datetime]
     last_updated_by: Optional[str]
-
-    @root_validator(pre=True)
-    def cast_string_to_enum(cls, values: Dict):
-        """Metadata files store the name of the enum value. This doesn't
-        natively deserialise into the Enum type for the pydantic Model
-        field. This validator handles that case.
-
-        Example json file field:
-        ...
-        "dataset_state": "INPUT_DATA",
-        ...
-
-        Should be deserialised into the Model as DatasetState.INPUT_DATA
-        """
-        field: ModelField
-        for key in values.keys():
-            field = cls.__fields__[key]
-            if (
-                values[key] is not None
-                and issubclass(field.type_, LanguageStringsEnum)
-                and not isinstance(values[key], LanguageStringsEnum)
-            ):
-                logger.debug(f"Casting {values[field.name] = } to {field.type_}")
-                try:
-                    values[key] = field.type_[values[key]]
-                except KeyError as e:
-                    raise ValueError(
-                        f"Provided value {values[key]} is not a valid member of {field.type_}. Valid members: {field.type_._member_names_}",
-                    ) from e
-        return values
 
 
 class DataDocVariable(DataDocBaseModel):

--- a/datadoc_model/Model.py
+++ b/datadoc_model/Model.py
@@ -1,7 +1,6 @@
 from datetime import date, datetime
-from typing import List, Optional, Dict
-from pydantic import constr, conint, root_validator
-from pydantic.fields import ModelField
+from typing import List, Optional
+from pydantic import constr, conint
 import logging
 
 from datadoc_model import Enums
@@ -9,7 +8,7 @@ from datadoc_model.BaseModel import DataDocBaseModel
 from datadoc_model.LanguageStrings import LanguageStrings
 from datadoc_model.LanguageStringsEnum import LanguageStringsEnum
 
-MODEL_VERSION = "0.1.0"
+MODEL_VERSION = "0.1.1"
 
 ALPHANUMERIC_HYPHEN_UNDERSCORE = "[-A-Za-z0-9_.*/]"
 URL_FORMAT = "(https?:\/\/)?(www\.)?[a-zA-Z0-9]+([-a-zA-Z0-9.]{1,254}[A-Za-z0-9])?\.[a-zA-Z0-9()]{1,6}([\/][-a-zA-Z0-9_]+)*[\/]?"  # noqa: W605

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,73 @@
 [[package]]
+name = "black"
+version = "22.6.0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
+typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "click"
+version = "8.1.3"
+description = "Composable command line interface toolkit"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
+name = "colorama"
+version = "0.4.5"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pathspec"
+version = "0.9.0"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
+name = "platformdirs"
+version = "2.5.2"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
+test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
+
+[[package]]
 name = "pydantic"
 version = "1.9.1"
 description = "Data validation and settings management using python type hints"
@@ -14,6 +83,14 @@ dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
 
 [[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "typing-extensions"
 version = "4.3.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -24,9 +101,54 @@ python-versions = ">=3.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "e30d5ddc924e9e88fdad335644f6bcf17cd0d1567f441979bf1f289202aa9c75"
+content-hash = "157cd39b289607f2e5037511a6c61f01107c8d952186e30ab3f13a0aa379730a"
 
 [metadata.files]
+black = [
+    {file = "black-22.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69"},
+    {file = "black-22.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807"},
+    {file = "black-22.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6797f58943fceb1c461fb572edbe828d811e719c24e03375fd25170ada53825e"},
+    {file = "black-22.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c85928b9d5f83b23cee7d0efcb310172412fbf7cb9d9ce963bd67fd141781def"},
+    {file = "black-22.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:f6fe02afde060bbeef044af7996f335fbe90b039ccf3f5eb8f16df8b20f77666"},
+    {file = "black-22.6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cfaf3895a9634e882bf9d2363fed5af8888802d670f58b279b0bece00e9a872d"},
+    {file = "black-22.6.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94783f636bca89f11eb5d50437e8e17fbc6a929a628d82304c80fa9cd945f256"},
+    {file = "black-22.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2ea29072e954a4d55a2ff58971b83365eba5d3d357352a07a7a4df0d95f51c78"},
+    {file = "black-22.6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e439798f819d49ba1c0bd9664427a05aab79bfba777a6db94fd4e56fae0cb849"},
+    {file = "black-22.6.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c"},
+    {file = "black-22.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:074458dc2f6e0d3dab7928d4417bb6957bb834434516f21514138437accdbe90"},
+    {file = "black-22.6.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a218d7e5856f91d20f04e931b6f16d15356db1c846ee55f01bac297a705ca24f"},
+    {file = "black-22.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:568ac3c465b1c8b34b61cd7a4e349e93f91abf0f9371eda1cf87194663ab684e"},
+    {file = "black-22.6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6c1734ab264b8f7929cef8ae5f900b85d579e6cbfde09d7387da8f04771b51c6"},
+    {file = "black-22.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9a3ac16efe9ec7d7381ddebcc022119794872abce99475345c5a61aa18c45ad"},
+    {file = "black-22.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:b9fd45787ba8aa3f5e0a0a98920c1012c884622c6c920dbe98dbd05bc7c70fbf"},
+    {file = "black-22.6.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7ba9be198ecca5031cd78745780d65a3f75a34b2ff9be5837045dce55db83d1c"},
+    {file = "black-22.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a3db5b6409b96d9bd543323b23ef32a1a2b06416d525d27e0f67e74f1446c8f2"},
+    {file = "black-22.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:560558527e52ce8afba936fcce93a7411ab40c7d5fe8c2463e279e843c0328ee"},
+    {file = "black-22.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b154e6bbde1e79ea3260c4b40c0b7b3109ffcdf7bc4ebf8859169a6af72cd70b"},
+    {file = "black-22.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:4af5bc0e1f96be5ae9bd7aaec219c901a94d6caa2484c21983d043371c733fc4"},
+    {file = "black-22.6.0-py3-none-any.whl", hash = "sha256:ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c"},
+    {file = "black-22.6.0.tar.gz", hash = "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9"},
+]
+click = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
+colorama = [
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+pathspec = [
+    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
+    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+]
+platformdirs = [
+    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
+    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
+]
 pydantic = [
     {file = "pydantic-1.9.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c8098a724c2784bf03e8070993f6d46aa2eeca031f8d8a048dff277703e6e193"},
     {file = "pydantic-1.9.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c320c64dd876e45254bdd350f0179da737463eea41c43bacbee9d8c9d1021f11"},
@@ -63,5 +185,9 @@ pydantic = [
     {file = "pydantic-1.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:61b6760b08b7c395975d893e0b814a11cf011ebb24f7d869e7118f5a339a82e1"},
     {file = "pydantic-1.9.1-py3-none-any.whl", hash = "sha256:4988c0f13c42bfa9ddd2fe2f569c9d54646ce84adc5de84228cfe83396f3bd58"},
     {file = "pydantic-1.9.1.tar.gz", hash = "sha256:1ed987c3ff29fff7fd8c3ea3a3ea877ad310aae2ef9889a119e22d3f2db0691a"},
+]
+tomli = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 typing-extensions = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,34 @@
 [[package]]
+name = "appnope"
+version = "0.1.3"
+description = "Disable App Nap on macOS >= 10.9"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "asttokens"
+version = "2.0.7"
+description = "Annotate AST trees with source code positions"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = "*"
+
+[package.extras]
+test = ["astroid (<=2.5.3)", "pytest"]
+
+[[package]]
+name = "backcall"
+version = "0.2.0"
+description = "Specifications for callback functions passed in to an API"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "black"
 version = "22.6.0"
 description = "The uncompromising code formatter."
@@ -40,12 +70,101 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "decorator"
+version = "5.1.1"
+description = "Decorators for Humans"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "executing"
+version = "0.9.1"
+description = "Get the currently executing AST node of a frame, and other information"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "ipython"
+version = "8.4.0"
+description = "IPython: Productive Interactive Computing"
+category = "dev"
+optional = false
+python-versions = ">=3.8"
+
+[package.dependencies]
+appnope = {version = "*", markers = "sys_platform == \"darwin\""}
+backcall = "*"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+decorator = "*"
+jedi = ">=0.16"
+matplotlib-inline = "*"
+pexpect = {version = ">4.3", markers = "sys_platform != \"win32\""}
+pickleshare = "*"
+prompt-toolkit = ">=2.0.0,<3.0.0 || >3.0.0,<3.0.1 || >3.0.1,<3.1.0"
+pygments = ">=2.4.0"
+stack-data = "*"
+traitlets = ">=5"
+
+[package.extras]
+test_extra = ["trio", "pandas", "numpy (>=1.19)", "nbformat", "matplotlib (!=3.2.0)", "curio", "testpath", "pytest-asyncio", "pytest (<7.1)"]
+test = ["testpath", "pytest-asyncio", "pytest (<7.1)"]
+qtconsole = ["qtconsole"]
+parallel = ["ipyparallel"]
+notebook = ["notebook", "ipywidgets"]
+nbformat = ["nbformat"]
+nbconvert = ["nbconvert"]
+kernel = ["ipykernel"]
+doc = ["Sphinx (>=1.3)"]
+black = ["black"]
+all = ["trio", "pandas", "numpy (>=1.19)", "matplotlib (!=3.2.0)", "curio", "testpath", "pytest-asyncio", "pytest (<7.1)", "qtconsole", "ipyparallel", "notebook", "ipywidgets", "nbformat", "nbconvert", "ipykernel", "Sphinx (>=1.3)", "black"]
+
+[[package]]
+name = "jedi"
+version = "0.18.1"
+description = "An autocompletion tool for Python that can be used for text editors."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+parso = ">=0.8.0,<0.9.0"
+
+[package.extras]
+testing = ["pytest (<7.0.0)", "docopt", "colorama", "Django (<3.1)"]
+qa = ["mypy (==0.782)", "flake8 (==3.8.3)"]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.1.3"
+description = "Inline Matplotlib backend for Jupyter"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+traitlets = "*"
+
+[[package]]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "parso"
+version = "0.8.3"
+description = "A Python Parser"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
+testing = ["docopt", "pytest (<6.0.0)"]
 
 [[package]]
 name = "pathspec"
@@ -56,6 +175,25 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
+name = "pexpect"
+version = "4.8.0"
+description = "Pexpect allows easy control of interactive console applications."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+ptyprocess = ">=0.5"
+
+[[package]]
+name = "pickleshare"
+version = "0.7.5"
+description = "Tiny 'shelve'-like database with concurrency support"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "platformdirs"
 version = "2.5.2"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -64,8 +202,38 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
-test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
+test = ["pytest (>=6)", "pytest-mock (>=3.6)", "pytest-cov (>=2.7)", "appdirs (==1.4.4)"]
+docs = ["sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)", "proselint (>=0.10.2)", "furo (>=2021.7.5b38)"]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.30"
+description = "Library for building powerful interactive command lines in Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+wcwidth = "*"
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+description = "Run a subprocess in a pseudo terminal"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pure-eval"
+version = "0.2.2"
+description = "Safely evaluate AST nodes without side effects"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.extras]
+tests = ["pytest"]
 
 [[package]]
 name = "pydantic"
@@ -83,12 +251,55 @@ dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
 
 [[package]]
+name = "pygments"
+version = "2.12.0"
+description = "Pygments is a syntax highlighting package written in Python."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "stack-data"
+version = "0.3.0"
+description = "Extract data from python stack frames and tracebacks for informative displays"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+asttokens = "*"
+executing = "*"
+pure-eval = "*"
+
+[package.extras]
+tests = ["cython", "littleutils", "pygments", "typeguard", "pytest"]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "traitlets"
+version = "5.3.0"
+description = ""
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest", "pre-commit"]
 
 [[package]]
 name = "typing-extensions"
@@ -98,12 +309,32 @@ category = "main"
 optional = false
 python-versions = ">=3.7"
 
+[[package]]
+name = "wcwidth"
+version = "0.2.5"
+description = "Measures the displayed width of unicode strings in a terminal"
+category = "dev"
+optional = false
+python-versions = "*"
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "157cd39b289607f2e5037511a6c61f01107c8d952186e30ab3f13a0aa379730a"
+content-hash = "f5ceb8d7e4230fb204bcb86d6a59f2f7ce2fcec43b820443c1eb256f58770c44"
 
 [metadata.files]
+appnope = [
+    {file = "appnope-0.1.3-py2.py3-none-any.whl", hash = "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"},
+    {file = "appnope-0.1.3.tar.gz", hash = "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24"},
+]
+asttokens = [
+    {file = "asttokens-2.0.7-py2.py3-none-any.whl", hash = "sha256:f5589ef8518f73dd82c15e1c19f795d8a62c133485e557c04443d4a1a730cf9f"},
+    {file = "asttokens-2.0.7.tar.gz", hash = "sha256:8444353e4e2a99661c8dfb85ec9c02eedded08f0006234bff7db44a06840acc2"},
+]
+backcall = [
+    {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
+    {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
+]
 black = [
     {file = "black-22.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69"},
     {file = "black-22.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807"},
@@ -137,17 +368,61 @@ colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
+decorator = [
+    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
+    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
+]
+executing = [
+    {file = "executing-0.9.1-py2.py3-none-any.whl", hash = "sha256:4ce4d6082d99361c0231fc31ac1a0f56979363cc6819de0b1410784f99e49105"},
+    {file = "executing-0.9.1.tar.gz", hash = "sha256:ea278e2cf90cbbacd24f1080dd1f0ac25b71b2e21f50ab439b7ba45dd3195587"},
+]
+ipython = [
+    {file = "ipython-8.4.0-py3-none-any.whl", hash = "sha256:7ca74052a38fa25fe9bedf52da0be7d3fdd2fb027c3b778ea78dfe8c212937d1"},
+    {file = "ipython-8.4.0.tar.gz", hash = "sha256:f2db3a10254241d9b447232cec8b424847f338d9d36f9a577a6192c332a46abd"},
+]
+jedi = [
+    {file = "jedi-0.18.1-py2.py3-none-any.whl", hash = "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d"},
+    {file = "jedi-0.18.1.tar.gz", hash = "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"},
+]
+matplotlib-inline = [
+    {file = "matplotlib-inline-0.1.3.tar.gz", hash = "sha256:a04bfba22e0d1395479f866853ec1ee28eea1485c1d69a6faf00dc3e24ff34ee"},
+    {file = "matplotlib_inline-0.1.3-py3-none-any.whl", hash = "sha256:aed605ba3b72462d64d475a21a9296f400a19c4f74a31b59103d2a99ffd5aa5c"},
+]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+parso = [
+    {file = "parso-0.8.3-py2.py3-none-any.whl", hash = "sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75"},
+    {file = "parso-0.8.3.tar.gz", hash = "sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0"},
 ]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
 ]
+pexpect = [
+    {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},
+    {file = "pexpect-4.8.0.tar.gz", hash = "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"},
+]
+pickleshare = [
+    {file = "pickleshare-0.7.5-py2.py3-none-any.whl", hash = "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"},
+    {file = "pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca"},
+]
 platformdirs = [
     {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
     {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
+]
+prompt-toolkit = [
+    {file = "prompt_toolkit-3.0.30-py3-none-any.whl", hash = "sha256:d8916d3f62a7b67ab353a952ce4ced6a1d2587dfe9ef8ebc30dd7c386751f289"},
+    {file = "prompt_toolkit-3.0.30.tar.gz", hash = "sha256:859b283c50bde45f5f97829f77a4674d1c1fcd88539364f1b28a37805cfd89c0"},
+]
+ptyprocess = [
+    {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
+    {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
+]
+pure-eval = [
+    {file = "pure_eval-0.2.2-py3-none-any.whl", hash = "sha256:01eaab343580944bc56080ebe0a674b39ec44a945e6d09ba7db3cb8cec289350"},
+    {file = "pure_eval-0.2.2.tar.gz", hash = "sha256:2b45320af6dfaa1750f543d714b6d1c520a1688dec6fd24d339063ce0aaa9ac3"},
 ]
 pydantic = [
     {file = "pydantic-1.9.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c8098a724c2784bf03e8070993f6d46aa2eeca031f8d8a048dff277703e6e193"},
@@ -186,8 +461,31 @@ pydantic = [
     {file = "pydantic-1.9.1-py3-none-any.whl", hash = "sha256:4988c0f13c42bfa9ddd2fe2f569c9d54646ce84adc5de84228cfe83396f3bd58"},
     {file = "pydantic-1.9.1.tar.gz", hash = "sha256:1ed987c3ff29fff7fd8c3ea3a3ea877ad310aae2ef9889a119e22d3f2db0691a"},
 ]
+pygments = [
+    {file = "Pygments-2.12.0-py3-none-any.whl", hash = "sha256:dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519"},
+    {file = "Pygments-2.12.0.tar.gz", hash = "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+stack-data = [
+    {file = "stack_data-0.3.0-py3-none-any.whl", hash = "sha256:aa1d52d14d09c7a9a12bb740e6bdfffe0f5e8f4f9218d85e7c73a8c37f7ae38d"},
+    {file = "stack_data-0.3.0.tar.gz", hash = "sha256:77bec1402dcd0987e9022326473fdbcc767304892a533ed8c29888dacb7dddbc"},
+]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
-typing-extensions = []
+traitlets = [
+    {file = "traitlets-5.3.0-py3-none-any.whl", hash = "sha256:65fa18961659635933100db8ca120ef6220555286949774b9cfc106f941d1c7a"},
+    {file = "traitlets-5.3.0.tar.gz", hash = "sha256:0bb9f1f9f017aa8ec187d8b1b2a7a6626a2a1d877116baba52a129bfa124f8e2"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
+    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
+]
+wcwidth = [
+    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
+    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssb-datadoc-model"
-version = "0.1.1"
+version = "0.1.2"
 description = "Data Model for use in Statistics Norway's Metadata system"
 authors = ["Statistics Norway <mmw@ssb.no>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ python = "^3.8"
 pydantic = "^1.9.1"
 
 [tool.poetry.dev-dependencies]
+black = "^22.6.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pydantic = "^1.9.1"
 
 [tool.poetry.dev-dependencies]
 black = "^22.6.0"
+ipython = "^8.4.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Add support for displaying Enums in multiple languages. We support entering and displaying metadata strings in multiple languages such that information is available to people from varied cultural backgrounds. This adds support to do the same with enum values.

This is implemented by subclassing `Enum` to `LanguageStringsEnum`. This stores the translations as an instance member and we provide a method to access the translation for a desired method.

Only the patch version of the Model is incremented because we retain backwards compatibility with the previous version

[STAT-15]

[STAT-15]: https://statistics-norway.atlassian.net/browse/STAT-15?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ