### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in the repo.
 # They will be requested for review when someone opens a pull request.
-* @statisticsnorway/dapla-stat-developers
+* @statisticsnorway/dapla-metadata-developers @BjornRoarJoneid


### PR DESCRIPTION
The ownership of this product is moving to Team Metadata, thus we must update the CODEOWNERS file.