### PR TITLE
Update vulnerable commons lang version

### DIFF
--- a/generated/java/datadoc-model/pom.xml
+++ b/generated/java/datadoc-model/pom.xml
@@ -16,7 +16,7 @@
     <github.repository>statisticsnorway/ssb-datadoc-model</github.repository>
 
     <!-- Dependency versions -->
-    <commons-lang.version>2.6</commons-lang.version>
+    <commons-lang.version>3.18.0</commons-lang.version>
     <jackson-databind.version>2.16.0</jackson-databind.version>
     <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
 
@@ -33,8 +33,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
       <version>${commons-lang.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Ref: https://github.com/statisticsnorway/ssb-datadoc-model/issues/87

The severity is medium and the risk score is not very high, but it is worth updating to the a version without the reported vulnerability

<img width="931" height="43" alt="Skjermbilde 2026-06-16 kl  21 56 17" src="https://github.com/user-attachments/assets/79345036-5eac-4008-a918-783b49beb8e7" />


