### PR TITLE
Update PyPI publish action to comply with SHA pinning policy

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Publish package on PyPI
         if: (steps.check-version.outputs.tag) || (github.event_name == 'workflow_dispatch')
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: generated/python/datadoc_model/dist
 


### PR DESCRIPTION
Update `pypa/gh-action-pypi-publish` from v1.12.4 to v1.14.2, which pins its internal dependency to full SHA.

The previous version internally referenced `actions/setup-python@v5`, which is rejected by our policy.